### PR TITLE
update coverage badge

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,15 +62,15 @@ func main() {
 
 		defer conn.Close()
 		if coverage, err := redis.GetCoverage(conn, repo); err != nil {
-			r.Redirect(fmt.Sprintf("http://img.shields.io/badge/gocover.io-error-lightgrey.svg"))
+			r.Redirect(fmt.Sprintf("https://img.shields.io/badge/coverage-error-lightgrey.svg"))
 		} else if coverage < 25.0 {
-			r.Redirect(fmt.Sprintf("http://img.shields.io/badge/gocover.io-%.1f%%-red.svg", coverage))
+			r.Redirect(fmt.Sprintf("https://img.shields.io/badge/coverage-%.1f%%-red.svg", coverage))
 		} else if coverage < 50.0 {
-			r.Redirect(fmt.Sprintf("http://img.shields.io/badge/gocover.io-%.1f%%-orange.svg", coverage))
+			r.Redirect(fmt.Sprintf("https://img.shields.io/badge/coverage-%.1f%%-orange.svg", coverage))
 		} else if coverage < 75.0 {
-			r.Redirect(fmt.Sprintf("http://img.shields.io/badge/gocover.io-%.1f%%-green.svg", coverage))
+			r.Redirect(fmt.Sprintf("https://img.shields.io/badge/coverage-%.1f%%-green.svg", coverage))
 		} else {
-			r.Redirect(fmt.Sprintf("http://img.shields.io/badge/gocover.io-%.1f%%-brightgreen.svg", coverage))
+			r.Redirect(fmt.Sprintf("https://img.shields.io/badge/coverage-%.1f%%-brightgreen.svg", coverage))
 		}
 
 	})


### PR DESCRIPTION
- Use https to prevent caching on GitHub.
- The [Shields spec](https://github.com/badges/shields/blob/master/spec/SPECIFICATION.md) recommends making badges _informational_ rather than _promotional_.

ref #3
