### PR TITLE
Updated default to Go 1.6

### DIFF
--- a/server/templates/cover.tmpl
+++ b/server/templates/cover.tmpl
@@ -17,8 +17,8 @@
                   	<button class="btn btn-info" type="button" onclick="parent.location='/'+document.getElementById('repo').value"><span class="glyphicon glyphicon-wrench"></span> Go</button>
 			<button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button>
 			<ul class="dropdown-menu">
-				<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value">go1.5.3</a></li>
-				<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value+'?version=1.6rc2'">go1.6rc2</a></li>
+				<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value">go1.6</a></li>
+				<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value+'?version=1.5.3'">go1.5.3</a></li>
 				<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value+'?version=1.4.3'">go1.4.3</a></li>
 				<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value+'?version=1.3.3'">go1.3.3</a></li>
              		       	<li><a href="#" onclick="parent.location='/'+document.getElementById('repo').value+'?version=1.2.2'">go1.2.2</a></li>

--- a/workers/gen.sh
+++ b/workers/gen.sh
@@ -1,5 +1,5 @@
-VERSIONS="1.2.2 1.3 1.3.1 1.3.2 1.3.3 1.4 1.4.1 1.4.2 1.4.3 1.5 1.5.1 1.5.2 1.5.3 1.6rc2"
-LATEST="1.5.3"
+VERSIONS="1.2.2 1.3 1.3.1 1.3.2 1.3.3 1.4 1.4.1 1.4.2 1.4.3 1.5 1.5.1 1.5.2 1.5.3 1.6"
+LATEST="1.6"
 
 for version in $VERSIONS; do
     docker build --build-arg GO_VERSION=$version -t vieux/gocover:$version . 

--- a/workers/push.sh
+++ b/workers/push.sh
@@ -1,4 +1,4 @@
-VERSIONS="1.2.2 1.3 1.3.1 1.3.2 1.3.3 1.4 1.4.1 1.4.2 1.4.3 1.5 1.5.1 1.5.2 1.5.3 1.6rc2 latest"
+VERSIONS="1.2.2 1.3 1.3.1 1.3.2 1.3.3 1.4 1.4.1 1.4.2 1.4.3 1.5 1.5.1 1.5.2 1.5.3 1.6 latest"
 for version in $VERSIONS; do
     docker push vieux/gocover:$version
 done


### PR DESCRIPTION
I updated the newest version to 1.6. **Please read to check for typos.**

There are two things I'm not sure about:

1. IN push.sh, why do you have "latest" and the latest version (1.5.3 before I edited it) listed?
2. Why do you have way more containers built by Docker than you can choose with the dropdown on the website?